### PR TITLE
Fix session tracker loading and syntax errors

### DIFF
--- a/static/js/optimized-session-tracker.js
+++ b/static/js/optimized-session-tracker.js
@@ -1336,9 +1336,7 @@ class OptimizedSessionTracker {
       this.log('Failed to clear session data: ' + error.message, 'error');
     }
   }
-</text>
 
-<old_text line=579>
   sendHeartbeat() {
     if (!this.state.isActive || !this.state.userId) return;
 

--- a/staticfiles/js/optimized-session-tracker.51d647b84ea6.js
+++ b/staticfiles/js/optimized-session-tracker.51d647b84ea6.js
@@ -1316,9 +1316,7 @@ class OptimizedSessionTracker {
       this.log('Failed to clear session data: ' + error.message, 'error');
     }
   }
-</text>
 
-<old_text line=579>
   sendHeartbeat() {
     if (!this.state.isActive || !this.state.userId) return;
 

--- a/staticfiles/js/optimized-session-tracker.c5486d94662a.js
+++ b/staticfiles/js/optimized-session-tracker.c5486d94662a.js
@@ -1333,9 +1333,7 @@ class OptimizedSessionTracker {
       this.log('Failed to clear session data: ' + error.message, 'error');
     }
   }
-</text>
 
-<old_text line=579>
   sendHeartbeat() {
     if (!this.state.isActive || !this.state.userId) return;
 

--- a/staticfiles/js/optimized-session-tracker.js
+++ b/staticfiles/js/optimized-session-tracker.js
@@ -1333,9 +1333,7 @@ class OptimizedSessionTracker {
       this.log('Failed to clear session data: ' + error.message, 'error');
     }
   }
-</text>
 
-<old_text line=579>
   sendHeartbeat() {
     if (!this.state.isActive || !this.state.userId) return;
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove invalid XML-like tags from `optimized-session-tracker.js` files to fix a JavaScript syntax error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The presence of `<old_text line=579>` and `</text>` tags, likely from a merge conflict, caused an `Uncaught SyntaxError: Unexpected token '{'` that prevented the `OptimizedSessionTracker` from initializing and loading correctly on the dashboard. Removing these artifacts resolves the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-51dcaa80-a8bc-45f5-83c0-25532702fbbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51dcaa80-a8bc-45f5-83c0-25532702fbbe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>